### PR TITLE
Remove dependency on eth1 interface from script

### DIFF
--- a/net/README.md
+++ b/net/README.md
@@ -17,7 +17,7 @@
 5. It is recommended that you enable passwordless sudo on all servers as well.
    Example set up instructions can be found [here](http://askubuntu.com/questions/192050/how-to-run-sudo-command-with-no-password)
 
-6. Get the ip addresses (dns names work as well) of all the servers
+6. Get the IP addresses (dns names work as well) of all the servers and the network interface on which this IP address is configured
 
 ### Step1: Download the installer script
 Log into one of the servers and download the installer script using the following command:
@@ -28,8 +28,9 @@ for it to work.
 
 ### Step2: Provide executable privileges and run installer script
 - `chmod +x net_demo_installer`
-- Run net_demo_installer script:
-`./net_demo_installer <server_1_ip_or_dns> <server_2_ip_or_dns> . . .`
+- Run net_demo_installer script. NOTE: Provide the network interface information on which the IP is configured (as mentioned in Step 6 of pre-requisites):
+
+         `./net_demo_installer <server1_ip_or_dns>:<server1_nw_if> <server2_ip_or_dns>:<server2_nw_if> . . .`
 - The installer script will ask for username/password if passwordless ssh is not set during the installation
 
 ### Under the hoods
@@ -41,11 +42,9 @@ The installer script performs the following actions:
 - runs the ansible playbook which installs necessary packages and brings up the services
 
 ### Troubleshooting
-This is the first cut of installer script.
 The current limitations of the script are as follows:
+- The installer script is assumed to run from one of the server nodes in the cluster. This approach ensures that the required packages are installed only on the necessary nodes.
 - Connections to the servers are assumed to be on the default ssh port and the default username used is the local hostname
-- IPs are assumed to be on the eth1 interface (as they were ). If you have the IPs set on any other interface [eth{x}], 
-  please replace all occurences of "ansible_eth1" to "ansible_default_ipv4"/"ansible_eth{x}" in the installer script
 
 The script generates many files for bookkeeping during the installation procedure. 
 These files can be found under .gen folder in your installer directory. 

--- a/net/README.md
+++ b/net/README.md
@@ -28,9 +28,9 @@ for it to work.
 
 ### Step2: Provide executable privileges and run installer script
 - `chmod +x net_demo_installer`
-- Run net_demo_installer script. NOTE: Provide the network interface information on which the IP is configured (as mentioned in Step 6 of pre-requisites):
+- Run net_demo_installer script. NOTE: Provide the network interface information on which the IP is configured (as mentioned in Step 6 of pre-requisites). If no interface is specified, the script determines and uses the default network interface used by ansible:
 
-         `./net_demo_installer <server1_ip_or_dns>:<server1_nw_if> <server2_ip_or_dns>:<server2_nw_if> . . .`
+         `./net_demo_installer <server1_ip_or_dns>[:<server1_nw_if>] <server2_ip_or_dns>[:<server2_nw_if>] . . .`
 - The installer script will ask for username/password if passwordless ssh is not set during the installation
 
 ### Under the hoods

--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -20,7 +20,6 @@ function ParseArguments {
     for ((i=1; i<=$#; i++)); do
         node_name=node$i
         node_ip[$node_name]=$(echo ${!i} | cut -f1 -d:)
-        node_if[$node_name]=eth0
         if echo ${!i} | grep ":" > /dev/null; then
             node_if[$node_name]=$(echo ${!i} | cut -f2 -d:)
         fi
@@ -145,11 +144,6 @@ echo "\
 [defaults]
 host_key_checking = False" > ~/.ansible.cfg
 
-echo "Contents of $HOST_INVENTORY_FILE:"
-echo "-----------------"
-cat $HOST_INVENTORY_FILE
-echo "-----------------"
-
 # Verify ansible can reach all hosts
 echo "Verifying ansible reachability"
 ansible all -i $HOST_INVENTORY_FILE -a "/bin/cat /etc/issue.net" >& $HOST_LOG_FILE
@@ -205,10 +199,24 @@ set -e
 
 echo "-----------------"
 
+# Assign proper interface if nothing is specified by default
+for ((i=1; i<=$#; i++)); do
+    if [ "${node_if[node$i]}" == "" ]; then
+        node_if[node$i]=$(ansible node${i} -m setup $ans_opts -i $HOST_INVENTORY_FILE| grep -A 4 ansible_${node_if[node$i]} | grep interface | awk -F \" '{print $4}')
+	sed -i 's/\(.*node'${i}'.*\)monitor_interface=\(.*\)/\1monitor_interface='${node_if[node$i]}'\2/' $HOST_INVENTORY_FILE
+        echo "Assigning default interface for ${node_ip[node$i]} as ${node_if[node$i]}"
+    fi
+done
+
+echo "Contents of $HOST_INVENTORY_FILE:"
+echo "-----------------"
+cat $HOST_INVENTORY_FILE
+echo "-----------------"
+
 # Get IP of all nodes
 rm -rf $HOST_IP_LOG_FILE
 for ((i=1; i<=$#; i++)); do
-    ansible ${node_ip[node$i]} -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_${node_if[node$i]} | grep address | awk -F \" '{print $4}' >> $HOST_IP_LOG_FILE
+    ansible node$i -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_${node_if[node$i]} | grep address | awk -F \" '{print $4}' >> $HOST_IP_LOG_FILE
 done
 
 # Use netmaster's default ip as service vip

--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -11,6 +11,22 @@ ENV_FILE="./.gen/env.json"
 ANSIBLE_SITE_FILE="./ansible/site.yml"
 NETPLUGIN_HOSTGROUP="netplugin-node"
 
+num_nodes=$#
+declare -A node_if
+declare -A node_ip
+
+# Function to parse the arguments
+function ParseArguments {
+    for ((i=1; i<=$#; i++)); do
+        node_name=node$i
+        node_ip[$node_name]=$(echo ${!i} | cut -f1 -d:)
+        node_if[$node_name]=eth0
+        if echo ${!i} | grep ":" > /dev/null; then
+            node_if[$node_name]=$(echo ${!i} | cut -f2 -d:)
+        fi
+    done
+}
+
 # Function to get user confirmation to proceed
 function ConfirmPrompt {
   while true; do
@@ -34,7 +50,8 @@ function GenerateInventoryFile {
     echo "[$NETPLUGIN_HOSTGROUP]" > $HOST_INVENTORY_FILE
     echo "Writing to file for $# hosts"
     for ((i=1; i<=$#; i++)); do
-        echo "node$i ansible_ssh_host=${!i}" >> $HOST_INVENTORY_FILE
+        node_name=node$i
+        echo "${node_name} ansible_ssh_host=${node_ip[$node_name]} monitor_interface=${node_if[$node_name]}" >> $HOST_INVENTORY_FILE
     done
 }
 
@@ -56,13 +73,16 @@ fi
 
 ans_opts=
 
+# Parse the arguments to fetch IP and interface information
+ParseArguments $@
+
 echo " "
 echo "        ==Contiv Netplugin Demo Installer=="
 echo " "
 echo "Netplugin Cluster will be set up on the following servers: "
 echo " "
 for ((i=1; i<=$#; i++)); do
-    echo "  ${!i}  "
+    echo "  ${node_ip[node$i]}  "
 done
 echo " "
 echo "IMPORTANT: You need to specify ALL hosts you're adding to the cluster"
@@ -187,13 +207,20 @@ echo "-----------------"
 
 # Get IP of all nodes
 rm -rf $HOST_IP_LOG_FILE
-ansible $NETPLUGIN_HOSTGROUP -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_eth1 | grep address | awk -F \" '{print $4}' >> $HOST_IP_LOG_FILE
-# Use netmaster's default ip as service vip
-svc_vip=$(ansible node1 -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_eth1 | grep address | awk -F \" '{print $4}')
-no_proxy=$(sed ':a;N;$!ba;s/\n/,/g' $HOST_IP_LOG_FILE)",127.0.0.1,localhost,netmaster"
-echo '{"env":{"http_proxy":"'$http_proxy'", "HTTP_PROXY":"'$http_proxy'", "https_proxy":"'$https_proxy'", "no_proxy":"'$no_proxy'"}, "monitor_interface": "eth1", "etcd_peers_group": '"\"$NETPLUGIN_HOSTGROUP\""', "service_vip": '"\"$svc_vip\""'}' > $ENV_FILE
-    ansible-playbook $ans_opts -i $HOST_INVENTORY_FILE  -e "`cat $ENV_FILE`" $ANSIBLE_SITE_FILE
+for ((i=1; i<=$#; i++)); do
+    ansible ${node_ip[node$i]} -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_${node_if[node$i]} | grep address | awk -F \" '{print $4}' >> $HOST_IP_LOG_FILE
+done
 
+# Use netmaster's default ip as service vip
+master_node=node1
+svc_vip=$(ansible $master_node -m setup $ans_opts -i $HOST_INVENTORY_FILE | grep -A 4 ansible_${node_if[$master_node]} | grep address | awk -F \" '{print $4}')
+no_proxy=$(sed ':a;N;$!ba;s/\n/,/g' $HOST_IP_LOG_FILE)",127.0.0.1,localhost,netmaster"
+echo '{"env":{"http_proxy":"'$http_proxy'", "HTTP_PROXY":"'$http_proxy'", "https_proxy":"'$https_proxy'", "no_proxy":"'$no_proxy'"}, "etcd_peers_group": '"\"$NETPLUGIN_HOSTGROUP\""', "service_vip": '"\"$svc_vip\""'}' > $ENV_FILE
+
+# Execute ansible-playbook to install the necessary services on the nodes
+ansible-playbook $ans_opts -i $HOST_INVENTORY_FILE  -e "`cat $ENV_FILE`" $ANSIBLE_SITE_FILE
+
+# Verify if the installation is successful by checking status of installed services
 DOCKER_HOST=$(service swarm status | grep "tcp://" | awk '{ print $5 }')
 if [ -z "$DOCKER_HOST" ]; then
   echo "swarm status does not look correct. Please retry install."


### PR DESCRIPTION
The first cut of installation script assumes that the eth1 is the default interface on which the control IP is configured. This PR removes the dependency and makes it configurable per node.
