### PR TITLE
Update net_demo_installer

### DIFF
--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -162,7 +162,7 @@ fi
 
 if  [[ ${OS_TYPE} =~ ^CentOS ]]; then
     sudoExec yum install -y epel-release epel-testing git wget
-    sudoExec yum install -y ansible
+    sudoExec yum --enablerepo='epel-testing' install -y ansible
     docker_version="1.10.3"
 fi
 


### PR DESCRIPTION
adding yum --enablerepo='epel-testing' install -y ansible to install ansible 2.0.x verion. Current one installs ansible 1.9.x verison.
Tested it on Centos 7 image.
