### PR TITLE
Skip addons to avoid the gce dependency

### DIFF
--- a/k8s/setup_k8s_cluster.sh
+++ b/k8s/setup_k8s_cluster.sh
@@ -71,4 +71,4 @@ GetContiv
 ./parse_cluster.py $username
 
 # run ansible
-ansible-playbook -kK -i .contiv_k8s_inventory $top_dir/contrib/ansible/cluster.yml --skip-tags "contiv_restart" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin etcd_peers_group=masters"
+ansible-playbook -kK -i .contiv_k8s_inventory $top_dir/contrib/ansible/cluster.yml --skip-tags "contiv_restart,addons" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin etcd_peers_group=masters"


### PR DESCRIPTION
k8s-addons has a gce dependency. This causes install failures when gce is unavailable. This change is to skip addons as we don't use it now.
