### PR TITLE
cleanup netmaster entry in etc hosts

### DIFF
--- a/k8s/prepare.yml
+++ b/k8s/prepare.yml
@@ -20,6 +20,11 @@
   - name: Setup | hostname
     hostname: name="{{ name }}"
 
+  - name: Setup | clean up /etc/hosts netmaster entry
+    lineinfile: dest=/etc/hosts regexp=.*netmaster$ state=absent
+    tags:
+      - etc_hosts
+
   - name: Setup | clean up /etc/hosts
     lineinfile: dest=/etc/hosts regexp='.*       ' state=absent
     tags:


### PR DESCRIPTION
Because netmaster hosts entry is not cleaned up, stale netmaster ip entry remains causing etcd communication issues.

-bash-4.2# cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
12.1.1.100 netmaster --> stale netmaster entry
10.193.246.8 netmaster --> correct netmaster entry
10.193.246.8       k8master
10.193.246.9       contiv-k8-1
10.193.246.10       contiv-k8-2
