### PR TITLE
Changes in net_demo_installer script

### DIFF
--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -213,7 +213,6 @@ fi
 if  [[ ${OS_TYPE} =~ ^CentOS ]]; then
     sudoExec yum install -y epel-release epel-testing git wget
     sudoExec yum --enablerepo='epel-testing' install -y ansible
-    docker_version="1.11.1"
 fi
 
 if [ "$(which ansible)" == "" ]; then

--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -213,7 +213,7 @@ fi
 if  [[ ${OS_TYPE} =~ ^CentOS ]]; then
     sudoExec yum install -y epel-release epel-testing git wget
     sudoExec yum --enablerepo='epel-testing' install -y ansible
-    docker_version="1.10.3"
+    docker_version="1.11.1"
 fi
 
 if [ "$(which ansible)" == "" ]; then


### PR DESCRIPTION
Currently we are hard coding docker version for centos. After this change it will take docker version from docker_version ansible variable.
