### PR TITLE
Restricting net_demo_installer script to use specific version of ansible rather than using latest.

### DIFF
--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -22,6 +22,7 @@ ANSIBLE_CLEANUP_FILE="./ansible/cleanup.yml"
 NETPLUGIN_HOSTGROUP="netplugin-node"
 CFG_FILE=${CFG_FILE:-"./cfg.yml"}
 INTERACTIVE_MODE=${INTERACTIVE_MODE:-"yes"}
+ANSIBLE_VERSION=2.1.2.0
 
 SAMPLE_CFG_FILE_URL="https://raw.githubusercontent.com/contiv/demo/master/net/extras/sample_cfg.yml"
 SAMPLE_ACI_CFG_FILE_URL="https://raw.githubusercontent.com/contiv/demo/master/net/extras/sample_aci_cfg.yml"
@@ -206,13 +207,12 @@ if [[ ${OS_TYPE} =~ ^Ubuntu ]]; then
     # Install python, pip and ansible
     sudoExec apt-get update
     sudoExec apt-get install wget git build-essential python-dev software-properties-common -y
-    sudoExec apt-add-repository -y ppa:ansible/ansible
-    sudoExec apt-get install -y ansible
+    sudoExec pip install ansible==$ANSIBLE_VERSION
 fi
 
 if  [[ ${OS_TYPE} =~ ^CentOS ]]; then
     sudoExec yum install -y epel-release epel-testing git wget
-    sudoExec yum install -y ansible
+    sudoExec pip install ansible==$ANSIBLE_VERSION
 fi
 
 if [ "$(which ansible)" == "" ]; then


### PR DESCRIPTION
Resolving this bug : https://github.com/contiv/demo/issues/120

Opened related bug to ansible repo as well : https://github.com/ansible/ansible/issues/18475

Signed-off-by: Gaurav Dalvi <gaurav1424@gmail.com>

Fixes #120