### PR TITLE
Add master/worker role to the inventory data

### DIFF
--- a/net/extras/genInventoryFile.py
+++ b/net/extras/genInventoryFile.py
@@ -54,6 +54,9 @@ class Inventory:
             outFd.write(var_line)
             var_line = "netplugin_if={} ".format(connInfo[node]['data'])
             outFd.write(var_line)
+            role = connInfo[node].get('role', 'worker')
+            var_line = "run_as={} ".format(role)
+            outFd.write(var_line)
             var_line = "fwd_mode={}\n".format(self.fwdMode)
             outFd.write(var_line)
 


### PR DESCRIPTION
Specify role: master to allow using host vars, instead of playbook level vars to select nodes to user as master/worker. Playbook vars can still be used to override these.