### PR TITLE
removing contiv/ container images from installer script

### DIFF
--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -410,14 +410,6 @@ fi
 echo "Setting up services on nodes"
 ansible-playbook $ans_opts -i $HOST_INVENTORY_FILE  -e "`cat $ENV_FILE`" $ANSIBLE_SITE_FILE
 
-# Bring up containers for demo when provisioning in ACI mode
-if [ $network_mode == "ACI" ]; then
-    sudoExec docker pull contiv/web
-    sudoExec docker tag contiv/web web
-    sudoExec docker pull contiv/redis
-    sudoExec docker tag contiv/redis redis
-fi
-
 # Verify if the installation is successful by checking status of installed services
 set -x
 # validate swarm container is running


### PR DESCRIPTION
contiv/web image == 675 MB
contiv/redis image == 200MB.

Removing them from installer so installer wont error out when flaky network connection with hub.docker.com.

Signed-off-by: Gaurav Dalvi <gaurav1424@gmail.com>