### PR TITLE
net/net_demo_installer: use Docker 1.12.6

### DIFF
--- a/net/net_demo_installer
+++ b/net/net_demo_installer
@@ -194,7 +194,7 @@ function sudoExec() {
 : ${contiv_network_version:=v0.1-12-23-2016.19-44-42.UTC}
 echo "Using version: $contiv_network_version"
 
-docker_version="1.11.1"
+docker_version="1.12.6"
 : ${aci_gw_image:="contiv/aci-gw"}
 
 set -x


### PR DESCRIPTION
This change makes the demo script set up an environment which uses Docker 1.12.6. This should be a better default as it contains some security fixes and a lot of bug fixes.